### PR TITLE
fix(web): Set correct base href for GitHub Pages deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # FVM management, dependency fetching, building, analysis, and more.
 # It dynamically selects the shell (zsh for macOS, bash for others) for recipes.
 # ==============================================================================
+WEB_BASE_PATH := /sudokode/
 FVM_INSTALL_URL := https://fvm.app/install.sh
 UNAME_S := $(shell uname -s)
 VERSION=$(shell awk '/^version:/ {print $$2}' pubspec.yaml)
@@ -92,7 +93,7 @@ run: ## Run the app in debug mode.
 
 # build-web: Build the web application.
 build-web: ## Build the web application.
-	fvm flutter build web
+	fvm flutter build web --base-href $(WEB_BASE_PATH)
 
 # clean: Remove build artifacts.
 clean: ## Remove build artifacts.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here are some of the most common commands. For a full list, run `make help`.
 | :------------- | :------------------------------------------- |
 | `make setup`   | Sets up the project for the first time.      |
 | `make run`     | Runs the app in debug mode.                  |
-| `make build-web` | Creates a release build for the web.         |
+| `make build-web` | Creates a release build for GitHub Pages.    |
 | `make analyze` | Analyzes the Dart source code for issues.    |
 | `make format`  | Formats all Dart files in the project.       |
 | `make clean`   | Removes all build artifacts.                 |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: sudokode
 description: An AI-powered Sudoku game built with Flutter and Dart. Challenge yourself with generated puzzles and get a little help when you're stuck.
 publish_to: 'none'
 
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
   sdk: '>=3.4.0 <4.0.0'


### PR DESCRIPTION
The web application was not loading correctly on GitHub Pages because the base href was not set. The default base href is `/`, but for a project page on GitHub, it needs to be `/<repository-name>/`.

This commit updates the `build-web` Makefile target to include the `--base-href /sudokode/` flag, ensuring that all assets are loaded from the correct path. The README has also been updated to reflect the new purpose of the `build-web` command.