### PR TITLE
feat: Implement pause and resume functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An AI-powered Sudoku game built with Flutter and Dart. Challenge yourself with g
 -   **Conflict Highlighting**: Automatically highlights numbers that conflict in a row, column, or 3x3 box.
 -   **Interactive Number Pad**: Shows how many of each number are left to be placed.
 -   **Hint System**: Get up to 5 hints per game to help you when you're stuck.
+-   **Game Timer**: Tracks completion time.
 -   **Game Controls**: Easily start a new game or reset the current board.
 -   **Localization**: Supports multiple languages.
 
@@ -48,8 +49,6 @@ Here are some of the most common commands. For a full list, run `make help`.
 | `make help`    | Displays a list of all available commands.   |
 
 ## Future Enhancements
-
--   Game timer to track completion time.
 -   Difficulty levels (Easy, Medium, Hard, Expert).
 -   Save and load game state.
 -   Enhanced animations and sound effects.

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -15,5 +15,8 @@
     "resetDialogContent": "Sind Sie sicher, dass Sie das Spielfeld leeren und von vorne beginnen möchten?",
     "resetDialogNo": "Nein",
     "resetDialogTitle": "Spielfeld zurücksetzen?",
-    "resetDialogYes": "Ja"
+    "resetDialogYes": "Ja",
+    "solvedDialogTimeLabel": "Zeit",
+    "newShort": "Neu",
+    "resetShort": "Reset"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -15,5 +15,8 @@
     "resetDialogContent": "Are you sure you want to clear the board and start over?",
     "resetDialogNo": "No",
     "resetDialogTitle": "Reset Board?",
-    "resetDialogYes": "Yes"
+    "resetDialogYes": "Yes",
+    "solvedDialogTimeLabel": "Time",
+    "newShort": "New",
+    "resetShort": "Reset"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -15,5 +15,8 @@
     "resetDialogContent": "¿Estás seguro de que quieres limpiar el tablero y empezar de nuevo?",
     "resetDialogNo": "No",
     "resetDialogTitle": "¿Reiniciar Tablero?",
-    "resetDialogYes": "Sí"
+    "resetDialogYes": "Sí",
+    "solvedDialogTimeLabel": "Tiempo",
+    "newShort": "New",
+    "resetShort": "Reset"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -15,5 +15,8 @@
     "resetDialogContent": "Êtes-vous sûr de vouloir effacer la grille et recommencer ?",
     "resetDialogNo": "Non",
     "resetDialogTitle": "Réinitialiser la grille ?",
-    "resetDialogYes": "Oui"
+    "resetDialogYes": "Oui",
+    "solvedDialogTimeLabel": "Temps",
+    "newShort": "New",
+    "resetShort": "Reset"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -199,6 +199,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Yes'**
   String get resetDialogYes;
+
+  /// No description provided for @solvedDialogTimeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Time'**
+  String get solvedDialogTimeLabel;
+
+  /// No description provided for @newShort.
+  ///
+  /// In en, this message translates to:
+  /// **'New'**
+  String get newShort;
+
+  /// No description provided for @resetShort.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset'**
+  String get resetShort;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -58,4 +58,13 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get resetDialogYes => 'Ja';
+
+  @override
+  String get solvedDialogTimeLabel => 'Zeit';
+
+  @override
+  String get newShort => 'Neu';
+
+  @override
+  String get resetShort => 'Reset';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -58,4 +58,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get resetDialogYes => 'Yes';
+
+  @override
+  String get solvedDialogTimeLabel => 'Time';
+
+  @override
+  String get newShort => 'New';
+
+  @override
+  String get resetShort => 'Reset';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -58,4 +58,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get resetDialogYes => 'Sí';
+
+  @override
+  String get solvedDialogTimeLabel => 'Tiempo';
+
+  @override
+  String get newShort => 'New';
+
+  @override
+  String get resetShort => 'Reset';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -58,4 +58,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get resetDialogYes => 'Oui';
+
+  @override
+  String get solvedDialogTimeLabel => 'Temps';
+
+  @override
+  String get newShort => 'New';
+
+  @override
+  String get resetShort => 'Reset';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -58,4 +58,13 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get resetDialogYes => 'Evet';
+
+  @override
+  String get solvedDialogTimeLabel => 'Süre';
+
+  @override
+  String get newShort => 'New';
+
+  @override
+  String get resetShort => 'Reset';
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -15,5 +15,6 @@
     "resetDialogContent": "Tahtayı temizleyip yeniden başlamak istediğinizden emin misiniz?",
     "resetDialogNo": "Hayır",
     "resetDialogTitle": "Tahtayı Sıfırla?",
-    "resetDialogYes": "Evet"
+    "resetDialogYes": "Evet",
+    "solvedDialogTimeLabel": "Süre"
 }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'dart:math';
 import 'package:sudokode/models/sudoku_board.dart';
@@ -24,6 +25,10 @@ class _GameScreenState extends State<GameScreen> {
   late SudokuBoard _sudokuBoard;
   int? _selectedRow;
   int? _selectedCol;
+  final Stopwatch _stopwatch = Stopwatch();
+  Timer? _timer;
+  String _elapsedTime = '00:00';
+  bool _isPaused = false;
 
   bool get _isCellSelected => _selectedRow != null && _selectedCol != null;
 
@@ -32,9 +37,59 @@ class _GameScreenState extends State<GameScreen> {
     super.initState();
     _sudokuBoard = SudokuBoard();
     _sudokuBoard.generatePuzzle();
+    _startTimer();
+  }
+
+  @override
+  void dispose() {
+    _stopwatch.stop();
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _startTimer() {
+    _stopwatch.start();
+    // Update the UI every second.
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (_stopwatch.isRunning) {
+        setState(() {
+          _elapsedTime = _formatElapsedTime(_stopwatch.elapsed);
+        });
+      }
+    });
+  }
+
+  void _stopTimer() {
+    _stopwatch.stop();
+    _timer?.cancel();
+  }
+
+  void _resetTimer() {
+    _stopwatch.stop();
+    _stopwatch.reset();
+    setState(() {
+      _elapsedTime = '00:00';
+    });
+  }
+
+  void _togglePause() {
+    if (_sudokuBoard.isSolved()) {
+      return;
+    }
+    setState(() {
+      _isPaused = !_isPaused;
+      if (_isPaused) {
+        _stopwatch.stop();
+      } else {
+        _stopwatch.start();
+      }
+    });
   }
 
   void _onCellTap(int row, int col) {
+    if (_isPaused) {
+      return;
+    }
     setState(() {
       _selectedRow = row;
       _selectedCol = col;
@@ -42,11 +97,15 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   void _onNumberTap(int number) {
+    if (_isPaused) {
+      return;
+    }
     if (_isCellSelected) {
       if (!_sudokuBoard.isInitialValue(_selectedRow!, _selectedCol!)) {
         setState(() {
           _sudokuBoard.setValue(_selectedRow!, _selectedCol!, number);
           if (_sudokuBoard.isSolved()) {
+            _stopTimer();
             _showSolvedDialog();
           }
         });
@@ -55,6 +114,9 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   void _onEraseTap() {
+    if (_isPaused) {
+      return;
+    }
     if (_isCellSelected) {
       if (!_sudokuBoard.isInitialValue(_selectedRow!, _selectedCol!)) {
         setState(() {
@@ -65,12 +127,16 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   void _onHintTap() {
+        if (_isPaused) {
+      return;
+    }
     final hintCell = _sudokuBoard.useHint();
     if (hintCell != null) {
       setState(() {
         _selectedRow = hintCell.$1;
         _selectedCol = hintCell.$2;
         if (_sudokuBoard.isSolved()) {
+          _stopTimer();
           _showSolvedDialog();
         }
       });
@@ -83,6 +149,9 @@ class _GameScreenState extends State<GameScreen> {
       _sudokuBoard.generatePuzzle();
       _selectedRow = null;
       _selectedCol = null;
+      _resetTimer();
+      _startTimer();
+      _isPaused = false;
     });
   }
 
@@ -139,6 +208,9 @@ class _GameScreenState extends State<GameScreen> {
       _sudokuBoard.resetBoard();
       _selectedRow = null;
       _selectedCol = null;
+      _resetTimer();
+      _startTimer();
+      _isPaused = false;
     });
   }
 
@@ -150,6 +222,13 @@ class _GameScreenState extends State<GameScreen> {
       content: l10n.resetDialogContent,
       onConfirm: _resetBoard,
     );
+  }
+
+  String _formatElapsedTime(Duration duration) {
+    String twoDigits(int n) => n.toString().padLeft(2, '0');
+    String twoDigitMinutes = twoDigits(duration.inMinutes.remainder(60));
+    String twoDigitSeconds = twoDigits(duration.inSeconds.remainder(60));
+    return "$twoDigitMinutes:$twoDigitSeconds";
   }
 
   Future<void> _showSolvedDialog() async {
@@ -167,6 +246,7 @@ class _GameScreenState extends State<GameScreen> {
         Animation<double> secondaryAnimation,
       ) {
         return SolvedDialog(
+          elapsedTime: _elapsedTime,
           onPlayAgain: () {
             Navigator.of(context).pop();
             _newGame();
@@ -205,9 +285,12 @@ class _GameScreenState extends State<GameScreen> {
                     SizedBox(
                       width: componentWidth,
                       child: GameHeader(
+                        elapsedTime: _elapsedTime,
                         isBoardModified: _sudokuBoard.isModified(),
                         onResetTap: () => _onResetTap(context),
                         onNewGameTap: () => _onNewGameTap(context),
+                        onTimerTap: _togglePause,
+                        isPaused: _isPaused,
                       ),
                     ),
                     const SizedBox(height: 8),
@@ -221,18 +304,30 @@ class _GameScreenState extends State<GameScreen> {
                           selectedRow: _selectedRow,
                           selectedCol: _selectedCol,
                           onCellTap: _onCellTap,
+                          isPaused: _isPaused,
                         ),
                       ),
                     ),
-                    const SizedBox(height: 20),
-                    SizedBox(
-                      width: componentWidth,
-                      child: NumberPad(
-                        onNumberTap: _onNumberTap,
-                        onEraseTap: _onEraseTap,
-                        onHintTap: _onHintTap,
-                        remainingHints: _sudokuBoard.remainingHints,
-                        getOccurrences: _sudokuBoard.countOccurrences,
+                    AnimatedOpacity(
+                      opacity: _isPaused ? 0.0 : 1.0,
+                      duration: const Duration(milliseconds: 300),
+                      child: IgnorePointer(
+                        ignoring: _isPaused,
+                        child: Column(
+                          children: [
+                            const SizedBox(height: 20),
+                            SizedBox(
+                              width: componentWidth,
+                              child: NumberPad(
+                                onNumberTap: _onNumberTap,
+                                onEraseTap: _onEraseTap,
+                                onHintTap: _onHintTap,
+                                remainingHints: _sudokuBoard.remainingHints,
+                                getOccurrences: _sudokuBoard.countOccurrences,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ],

--- a/lib/widgets/game_header.dart
+++ b/lib/widgets/game_header.dart
@@ -3,15 +3,21 @@ import 'package:flutter_shared_components/flutter_shared_components.dart';
 import 'package:sudokode/l10n/app_localizations.dart';
 
 class GameHeader extends StatelessWidget {
+  final String elapsedTime;
   final bool isBoardModified;
   final VoidCallback onResetTap;
   final VoidCallback onNewGameTap;
+  final VoidCallback onTimerTap;
+  final bool isPaused;
 
   const GameHeader({
     super.key,
+    required this.elapsedTime,
     required this.isBoardModified,
     required this.onResetTap,
     required this.onNewGameTap,
+    required this.onTimerTap,
+    required this.isPaused,
   });
 
   Widget _buildHeaderButton({
@@ -23,20 +29,57 @@ class GameHeader extends StatelessWidget {
   }) {
     return StyledActionButton(
       onPressed: onPressed,
-      padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-      child: Row(
+      padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
+      child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(
             icon,
             color: onSurfaceColor,
+            size: 20,
           ),
-          const SizedBox(width: 8),
+          const SizedBox(height: 4),
           Text(
             text,
             style: TextStyle(
               fontWeight: FontWeight.bold,
               color: onSurfaceColor,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimerButton({
+    required BuildContext context,
+    required String text,
+    required Color onSurfaceColor,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final timerColor = isPaused ? colorScheme.secondary : onSurfaceColor;
+    final icon = isPaused ? Icons.pause_circle_outline : Icons.timer_outlined;
+
+    return StyledActionButton(
+      onPressed: onTimerTap,
+      padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            icon,
+            color: timerColor,
+            size: 20,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            text,
+            style: TextStyle(
+              fontFamily: 'monospace',
+              fontWeight: FontWeight.bold,
+              color: timerColor,
+              fontSize: 12,
             ),
           ),
         ],
@@ -105,26 +148,48 @@ class GameHeader extends StatelessWidget {
           ),
         ),
         const Spacer(),
-        Visibility(
-          visible: isBoardModified,
-          maintainSize: true,
-          maintainAnimation: true,
-          maintainState: true,
-          child: _buildHeaderButton(
-            context: context,
-            onPressed: onResetTap,
-            icon: Icons.refresh,
-            text: l10n.reset,
-            onSurfaceColor: colorScheme.onSurface,
-          ),
-        ),
-        const SizedBox(width: 8),
-        _buildHeaderButton(
-          context: context,
-          onPressed: onNewGameTap,
-          icon: Icons.autorenew,
-          text: l10n.newGame,
-          onSurfaceColor: colorScheme.onSurface,
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            AnimatedOpacity(
+              opacity: isPaused ? 0.0 : 1.0,
+              duration: const Duration(milliseconds: 300),
+              child: IgnorePointer(
+                ignoring: isPaused,
+                child: Row(
+                  children: [
+                    Visibility(
+                      visible: isBoardModified,
+                      maintainSize: true,
+                      maintainAnimation: true,
+                      maintainState: true,
+                      child: _buildHeaderButton(
+                        context: context,
+                        onPressed: onResetTap,
+                        icon: Icons.refresh_rounded,
+                        text: l10n.resetShort,
+                        onSurfaceColor: colorScheme.onSurface,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    _buildHeaderButton(
+                      context: context,
+                      onPressed: onNewGameTap,
+                      icon: Icons.autorenew_rounded,
+                      text: l10n.newShort,
+                      onSurfaceColor: colorScheme.onSurface,
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                ),
+              ),
+            ),
+            _buildTimerButton(
+              context: context,
+              text: elapsedTime,
+              onSurfaceColor: colorScheme.onSurface.withOpacity(0.85),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/widgets/number_pad.dart
+++ b/lib/widgets/number_pad.dart
@@ -28,7 +28,7 @@ class NumberPad extends StatelessWidget {
           crossAxisCount: 11,
           crossAxisSpacing: 8,
           mainAxisSpacing: 8,
-          childAspectRatio: 1.2,
+          childAspectRatio: 0.75,
         ),
         itemCount: 11,
         itemBuilder: (context, index) {

--- a/lib/widgets/solved_dialog.dart
+++ b/lib/widgets/solved_dialog.dart
@@ -4,9 +4,14 @@ import 'package:flutter/material.dart';
 import 'package:sudokode/l10n/app_localizations.dart';
 
 class SolvedDialog extends StatelessWidget {
+  final String elapsedTime;
   final VoidCallback onPlayAgain;
 
-  const SolvedDialog({super.key, required this.onPlayAgain});
+  const SolvedDialog({
+    super.key,
+    required this.elapsedTime,
+    required this.onPlayAgain,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +55,12 @@ class SolvedDialog extends StatelessWidget {
                   l10n.puzzleSolved,
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  '${l10n.solvedDialogTimeLabel}: $elapsedTime',
+                  style: const TextStyle(
+                      fontSize: 20, fontWeight: FontWeight.bold),
                 ),
                 const SizedBox(height: 24),
                 SizedBox(

--- a/lib/widgets/sudoku_cell.dart
+++ b/lib/widgets/sudoku_cell.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 
 const _initialValueColor = Color(0xFF1565C0);
@@ -9,6 +10,8 @@ class SudokuCell extends StatelessWidget {
   final bool isConflict;
   final VoidCallback? onTap;
   final Color cellBackgroundColor;
+    final bool isPaused;
+
 
   const SudokuCell({
     super.key,
@@ -18,6 +21,7 @@ class SudokuCell extends StatelessWidget {
     required this.isConflict,
     required this.onTap,
     required this.cellBackgroundColor,
+    required this.isPaused,
   });
 
   @override
@@ -46,13 +50,20 @@ class SudokuCell extends StatelessWidget {
               )
             ],
           ),
-          child: Center(
-            child: Text(
-              value == 0 ? '' : value.toString(),
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-                color: isInitial ? _initialValueColor : colorScheme.onSurface,
+          child: ImageFiltered(
+            imageFilter: ImageFilter.blur(
+              sigmaX: isPaused ? 4.0 : 0.0,
+              sigmaY: isPaused ? 4.0 : 0.0,
+              tileMode: TileMode.decal,
+            ),
+            child: Center(
+              child: Text(
+                value == 0 ? '' : value.toString(),
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: isInitial ? _initialValueColor : colorScheme.onSurface,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/sudoku_grid.dart
+++ b/lib/widgets/sudoku_grid.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:sudokode/models/sudoku_board.dart';
 import 'package:sudokode/widgets/sudoku_cell.dart';
@@ -10,6 +11,8 @@ class SudokuGrid extends StatelessWidget {
   final int? selectedRow;
   final int? selectedCol;
   final void Function(int, int) onCellTap;
+    final bool isPaused;
+
 
   const SudokuGrid({
     super.key,
@@ -17,6 +20,8 @@ class SudokuGrid extends StatelessWidget {
     required this.selectedRow,
     required this.selectedCol,
     required this.onCellTap,
+        required this.isPaused,
+
   });
 
   @override
@@ -77,6 +82,7 @@ class SudokuGrid extends StatelessWidget {
                     cellBackgroundColor: (boxIndex % 2 == 0)
                         ? colorScheme.surface
                         : colorScheme.surfaceContainer,
+                    isPaused: isPaused,
                   );
                 },
               );


### PR DESCRIPTION
This commit introduces a pause and resume feature to the game, enhancing the user experience by allowing them to take a break without losing their progress or being distracted by the puzzle.

Key changes include:

-   **Timer as a Control:** The timer display has been converted into a button. Tapping it now toggles the pause state of the game.
-   **Pause State UI:**
    -   When paused, the timer button's icon and color change to provide clear visual feedback.
    -   The numbers on the Sudoku grid are blurred, preventing the user from studying the puzzle.
    -   The number pad, "Reset", and "New Game" buttons fade out smoothly, creating a clean and focused pause screen while preventing jarring layout shifts.
-   **Interaction Lock:** All user interactions with the Sudoku grid and the number pad are disabled during the pause state.
-   **UI Consistency:** The layout of the header controls and the height of the number pad buttons have been adjusted for better visual harmony.