### PR TITLE
feat: Improve new game flow and difficulty selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An AI-powered Sudoku game built with Flutter and Dart. Challenge yourself with g
 -   **Responsive UI**: Adapts to different screen sizes for a great experience on web and mobile.
 -   **Dynamic Puzzle Generation**: Every new game provides a unique, solvable Sudoku puzzle.
 -   **Conflict Highlighting**: Automatically highlights numbers that conflict in a row, column, or 3x3 box.
+-   **Difficulty Levels**: Choose from Easy, Medium, Hard, or Expert to match your skill level.
 -   **Interactive Number Pad**: Shows how many of each number are left to be placed.
 -   **Hint System**: Get up to 5 hints per game to help you when you're stuck.
 -   **Game Timer**: Tracks completion time.
@@ -49,7 +50,6 @@ Here are some of the most common commands. For a full list, run `make help`.
 | `make help`    | Displays a list of all available commands.   |
 
 ## Future Enhancements
--   Difficulty levels (Easy, Medium, Hard, Expert).
 -   Save and load game state.
 -   Enhanced animations and sound effects.
 -   User statistics and leaderboards.

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -18,5 +18,10 @@
     "resetDialogYes": "Ja",
     "solvedDialogTimeLabel": "Zeit",
     "newShort": "Neu",
-    "resetShort": "Reset"
+    "resetShort": "Zurücksetzen",
+    "selectDifficulty": "Schwierigkeit wählen",
+    "difficultyEasy": "Einfach",
+    "difficultyMedium": "Mittel",
+    "difficultyHard": "Schwer",
+    "difficultyExpert": "Experte"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -18,5 +18,10 @@
     "resetDialogYes": "Yes",
     "solvedDialogTimeLabel": "Time",
     "newShort": "New",
-    "resetShort": "Reset"
+    "resetShort": "Reset",
+    "selectDifficulty": "Select Difficulty",
+    "difficultyEasy": "Easy",
+    "difficultyMedium": "Medium",
+    "difficultyHard": "Hard",
+    "difficultyExpert": "Expert"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -17,6 +17,11 @@
     "resetDialogTitle": "¿Reiniciar Tablero?",
     "resetDialogYes": "Sí",
     "solvedDialogTimeLabel": "Tiempo",
-    "newShort": "New",
-    "resetShort": "Reset"
+    "newShort": "Nuevo",
+    "resetShort": "Reiniciar",
+    "selectDifficulty": "Seleccionar Dificultad",
+    "difficultyEasy": "Fácil",
+    "difficultyMedium": "Medio",
+    "difficultyHard": "Difícil",
+    "difficultyExpert": "Experto"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -17,6 +17,11 @@
     "resetDialogTitle": "Réinitialiser la grille ?",
     "resetDialogYes": "Oui",
     "solvedDialogTimeLabel": "Temps",
-    "newShort": "New",
-    "resetShort": "Reset"
+    "newShort": "Nouveau",
+    "resetShort": "Réinit.",
+    "selectDifficulty": "Sélectionner la difficulté",
+    "difficultyEasy": "Facile",
+    "difficultyMedium": "Moyen",
+    "difficultyHard": "Difficile",
+    "difficultyExpert": "Expert"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -217,6 +217,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Reset'**
   String get resetShort;
+
+  /// No description provided for @selectDifficulty.
+  ///
+  /// In en, this message translates to:
+  /// **'Select Difficulty'**
+  String get selectDifficulty;
+
+  /// No description provided for @difficultyEasy.
+  ///
+  /// In en, this message translates to:
+  /// **'Easy'**
+  String get difficultyEasy;
+
+  /// No description provided for @difficultyMedium.
+  ///
+  /// In en, this message translates to:
+  /// **'Medium'**
+  String get difficultyMedium;
+
+  /// No description provided for @difficultyHard.
+  ///
+  /// In en, this message translates to:
+  /// **'Hard'**
+  String get difficultyHard;
+
+  /// No description provided for @difficultyExpert.
+  ///
+  /// In en, this message translates to:
+  /// **'Expert'**
+  String get difficultyExpert;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -66,5 +66,20 @@ class AppLocalizationsDe extends AppLocalizations {
   String get newShort => 'Neu';
 
   @override
-  String get resetShort => 'Reset';
+  String get resetShort => 'Zurücksetzen';
+
+  @override
+  String get selectDifficulty => 'Schwierigkeit wählen';
+
+  @override
+  String get difficultyEasy => 'Einfach';
+
+  @override
+  String get difficultyMedium => 'Mittel';
+
+  @override
+  String get difficultyHard => 'Schwer';
+
+  @override
+  String get difficultyExpert => 'Experte';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -67,4 +67,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get resetShort => 'Reset';
+
+  @override
+  String get selectDifficulty => 'Select Difficulty';
+
+  @override
+  String get difficultyEasy => 'Easy';
+
+  @override
+  String get difficultyMedium => 'Medium';
+
+  @override
+  String get difficultyHard => 'Hard';
+
+  @override
+  String get difficultyExpert => 'Expert';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -63,8 +63,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get solvedDialogTimeLabel => 'Tiempo';
 
   @override
-  String get newShort => 'New';
+  String get newShort => 'Nuevo';
 
   @override
-  String get resetShort => 'Reset';
+  String get resetShort => 'Reiniciar';
+
+  @override
+  String get selectDifficulty => 'Seleccionar Dificultad';
+
+  @override
+  String get difficultyEasy => 'Fácil';
+
+  @override
+  String get difficultyMedium => 'Medio';
+
+  @override
+  String get difficultyHard => 'Difícil';
+
+  @override
+  String get difficultyExpert => 'Experto';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -63,8 +63,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get solvedDialogTimeLabel => 'Temps';
 
   @override
-  String get newShort => 'New';
+  String get newShort => 'Nouveau';
 
   @override
-  String get resetShort => 'Reset';
+  String get resetShort => 'Réinit.';
+
+  @override
+  String get selectDifficulty => 'Sélectionner la difficulté';
+
+  @override
+  String get difficultyEasy => 'Facile';
+
+  @override
+  String get difficultyMedium => 'Moyen';
+
+  @override
+  String get difficultyHard => 'Difficile';
+
+  @override
+  String get difficultyExpert => 'Expert';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -63,8 +63,23 @@ class AppLocalizationsTr extends AppLocalizations {
   String get solvedDialogTimeLabel => 'Süre';
 
   @override
-  String get newShort => 'New';
+  String get newShort => 'Yeni';
 
   @override
-  String get resetShort => 'Reset';
+  String get resetShort => 'Sıfırla';
+
+  @override
+  String get selectDifficulty => 'Zorluk Seçin';
+
+  @override
+  String get difficultyEasy => 'Kolay';
+
+  @override
+  String get difficultyMedium => 'Orta';
+
+  @override
+  String get difficultyHard => 'Zor';
+
+  @override
+  String get difficultyExpert => 'Uzman';
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -16,5 +16,12 @@
     "resetDialogNo": "Hayır",
     "resetDialogTitle": "Tahtayı Sıfırla?",
     "resetDialogYes": "Evet",
-    "solvedDialogTimeLabel": "Süre"
+    "solvedDialogTimeLabel": "Süre",
+    "newShort": "Yeni",
+    "resetShort": "Sıfırla",
+    "selectDifficulty": "Zorluk Seçin",
+    "difficultyEasy": "Kolay",
+    "difficultyMedium": "Orta",
+    "difficultyHard": "Zor",
+    "difficultyExpert": "Uzman"
 }

--- a/lib/models/difficulty.dart
+++ b/lib/models/difficulty.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/foundation.dart' show immutable;
+import 'package:flutter/material.dart' show Icons;
+import 'package:flutter/widgets.dart' show BuildContext, IconData;
+import 'package:sudokode/l10n/app_localizations.dart';
+
+enum Difficulty {
+  easy,
+  medium,
+  hard,
+  expert,
+}
+
+@immutable
+class DifficultySettings {
+  final int emptyCells;
+  final int maxHints;
+  final IconData icon;
+
+  const DifficultySettings(
+      {required this.emptyCells, required this.maxHints, required this.icon});
+}
+
+extension DifficultyExtension on Difficulty {
+  // Using a map for settings for easier management and localization.
+  static final Map<Difficulty, DifficultySettings> _settings = {
+    Difficulty.easy: const DifficultySettings(
+      emptyCells: 40,
+      maxHints: 5,
+      icon: Icons.wb_sunny_outlined,
+    ),
+    Difficulty.medium: const DifficultySettings(
+      emptyCells: 50,
+      maxHints: 3,
+      icon: Icons.thermostat_outlined,
+    ),
+    Difficulty.hard: const DifficultySettings(
+      emptyCells: 55,
+      maxHints: 1,
+      icon: Icons.whatshot_outlined,
+    ),
+    Difficulty.expert: const DifficultySettings(
+      emptyCells: 60,
+      maxHints: 0,
+      icon: Icons.local_fire_department_outlined,
+    ),
+  };
+
+  String localizedName(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    switch (this) {
+      case Difficulty.easy: return l10n.difficultyEasy;
+      case Difficulty.medium: return l10n.difficultyMedium;
+      case Difficulty.hard: return l10n.difficultyHard;
+      case Difficulty.expert: return l10n.difficultyExpert;
+    }
+  }
+
+  IconData get icon => _settings[this]!.icon;
+  int get emptyCells => _settings[this]!.emptyCells;
+  int get maxHints => _settings[this]!.maxHints;
+}

--- a/lib/models/sudoku_board.dart
+++ b/lib/models/sudoku_board.dart
@@ -1,18 +1,21 @@
 import 'dart:math';
 
+import 'package:sudokode/models/difficulty.dart';
+
 class SudokuBoard {
   late List<List<int>> _board;
   late List<List<int>> _solutionBoard;
   late List<List<bool>> _initialValues;
   late List<List<bool>> _conflicts;
   int _hintsUsed = 0;
-  static const int maxHints = 5;
+  late int maxHints;
 
   SudokuBoard() {
     _board = List.generate(9, (_) => List.generate(9, (_) => 0));
     _solutionBoard = List.generate(9, (_) => List.generate(9, (_) => 0));
     _initialValues = List.generate(9, (_) => List.generate(9, (_) => false));
     _conflicts = List.generate(9, (_) => List.generate(9, (_) => false));
+    maxHints = 0; // Default value to prevent late initialization errors.
   }
 
   int getValue(int row, int col) => _board[row][col];
@@ -101,7 +104,10 @@ class SudokuBoard {
     return (row, col);
   }
 
-  void generatePuzzle() {
+  void generatePuzzle(Difficulty difficulty) {
+    maxHints = difficulty.maxHints;
+    _hintsUsed = 0;
+
     _fillBoard();
 
     _solutionBoard = List.generate(9, (r) => List.from(_board[r]));
@@ -114,7 +120,7 @@ class SudokuBoard {
       }
     }
 
-    _removeNumbers(45);
+    _removeNumbers(difficulty.emptyCells);
     validateBoard();
   }
 


### PR DESCRIPTION
Implements a more intuitive and user-friendly process for starting a new game.

**Initial Difficulty Selection:**
- The app now prompts the user to select a difficulty level immediately upon startup, ensuring a smoother start to the game.
- The initial difficulty dialog is non-dismissible, requiring a selection before the puzzle is generated.

**UI/UX Enhancements:**
- The difficulty selection dialog has been redesigned for better clarity and visual appeal.
- Each difficulty level now has a unique, descriptive icon.
- The dialog layout and styling have been refined for a more polished look.

**Localization:**
- Added missing translations for the new difficulty selection UI in German, French, and Turkish.

**Refactoring & Fixes:**
- The difficulty selection dialog logic has been refactored into a reusable method.
- Fixed a `LateInitializationError` by providing a default value for `maxHints` in the `SudokuBoard` model.