### PR TITLE
feat: Integrate rewarded ads for extra hints

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -36,12 +36,15 @@ if (flutterTargetSdkVersion == null) {
 
 android {
     namespace = "com.soloscripted.sudokode"
-    compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    compileSdk = 34
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+    kotlinOptions {
+        jvmTarget = '21'
     }
 
     defaultConfig {
@@ -49,8 +52,8 @@ android {
         applicationId = "com.soloscripted.sudokode"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdk = flutter.minSdkVersion
-        targetSdk = flutterTargetSdkVersion.toInteger()
+        minSdk = 21
+        targetSdk = 34
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName
         resConfigs "en", "es", "fr", "de", "tr"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-9378360412585533~8401439397"/>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+    ext.kotlin_version = '1.9.23'
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.4.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.7.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.23" apply false
 }
 
 include ":app"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,27 +2,51 @@ PODS:
   - app_tracking_transparency (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - Google-Mobile-Ads-SDK (11.10.0):
+    - GoogleUserMessagingPlatform (>= 1.1)
+  - google_mobile_ads (5.2.0):
+    - Flutter
+    - Google-Mobile-Ads-SDK (~> 11.10.0)
+    - webview_flutter_wkwebview
+  - GoogleUserMessagingPlatform (3.0.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - app_tracking_transparency (from `.symlinks/plugins/app_tracking_transparency/ios`)
   - Flutter (from `Flutter`)
+  - google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
+
+SPEC REPOS:
+  trunk:
+    - Google-Mobile-Ads-SDK
+    - GoogleUserMessagingPlatform
 
 EXTERNAL SOURCES:
   app_tracking_transparency:
     :path: ".symlinks/plugins/app_tracking_transparency/ios"
   Flutter:
     :path: Flutter
+  google_mobile_ads:
+    :path: ".symlinks/plugins/google_mobile_ads/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
   app_tracking_transparency: 3d84f147f67ca82d3c15355c36b1fa6b66ca7c92
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Google-Mobile-Ads-SDK: 13e6e98edfd78ad8d8a791edb927658cc260a56f
+  google_mobile_ads: dc2b2a5884bef7ab2b4ff30022a513df5373e208
+  GoogleUserMessagingPlatform: f8d0cdad3ca835406755d0a69aa634f00e76d576
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  webview_flutter_wkwebview: 45a041c7831641076618876de3ba75c712860c6b
 
 PODFILE CHECKSUM: 7be2f5f74864d463a8ad433546ed1de7e0f29aef
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				56A36E13F731175BE7BE141C /* [CP] Embed Pods Frameworks */,
+				CC572DBFFC950EB4EA75E611 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -388,6 +389,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CC572DBFFC950EB4EA75E611 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,5 +49,15 @@
 	<string>This allows us to provide you with personalized ads and improve our services.</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-9378360412585533~1370176931</string>
+	<key>SKAdNetworkItems</key>
+	<array>
+		<dict>
+			<key>SKAdNetworkIdentifier</key>
+			<string>cstr6suwn9.skadnetwork</string>
+		</dict>
+	</array>
+	
 </dict>
 </plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,21 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_shared_components/flutter_shared_components.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:sudokode/screens/game_screen.dart';
 import 'package:sudokode/services/game_stats.dart';
 import 'package:sudokode/l10n/app_localizations.dart';
 
-void main() {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  GameStats().loadStats();
+  await GameStats().loadStats();
+  // Initialize AdMob only on mobile platforms, not on web.
+  if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
+    await MobileAds.instance.initialize();
+  }
 
   runApp(const SoloScriptedApp(
     title: 'SudoKode',

--- a/lib/models/sudoku_board.dart
+++ b/lib/models/sudoku_board.dart
@@ -225,4 +225,9 @@ class SudokuBoard {
     }
     return true;
   }
+
+  void grantExtraHint() {
+    maxHints++;
+  }
+
 }

--- a/lib/screens/game_screen.dart
+++ b/lib/screens/game_screen.dart
@@ -1,8 +1,11 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:sudokode/l10n/app_localizations.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:sudokode/models/difficulty.dart';
 import 'package:sudokode/models/sudoku_board.dart';
 import 'package:sudokode/services/game_stats.dart';
@@ -34,12 +37,16 @@ class _GameScreenState extends State<GameScreen> {
   String _elapsedTime = '00:00';
   bool _isPaused = false;
   Difficulty _currentDifficulty = Difficulty.medium;
+  BannerAd? _bannerAd;
+  RewardedAd? _rewardedAd;
 
   bool get _isCellSelected => _selectedRow != null && _selectedCol != null;
 
   @override
   void initState() {
     super.initState();
+    _loadBannerAd();
+    _loadRewardedAd();
     _sudokuBoard = SudokuBoard();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _selectDifficultyAndStartGame(isCancellable: false);
@@ -48,9 +55,89 @@ class _GameScreenState extends State<GameScreen> {
 
   @override
   void dispose() {
+    _bannerAd?.dispose();
+    _rewardedAd?.dispose();
     _stopwatch.stop();
     _timer?.cancel();
     super.dispose();
+  }
+
+  void _loadBannerAd() {
+    // Ads are not supported on web, so we do nothing.
+    if (kIsWeb) {
+      return;
+    }
+
+    final adUnitId = Platform.isAndroid
+        ? 'ca-app-pub-9378360412585533/5895920315' 
+        : 'ca-app-pub-9378360412585533/7212570099'; 
+
+    _bannerAd = BannerAd(
+      adUnitId: adUnitId,
+      request: const AdRequest(),
+      size: AdSize.banner,
+      listener: BannerAdListener(
+        onAdLoaded: (ad) => setState(() {}),
+        onAdFailedToLoad: (ad, err) => ad.dispose(),
+      ),
+    )..load();
+  }
+
+  void _loadRewardedAd() {
+    if (kIsWeb) {
+      return;
+    }
+
+    // Use test ad unit IDs for development.
+    final adUnitId = Platform.isAndroid
+        ? 'ca-app-pub-9378360412585533/4998057024'
+        : 'ca-app-pub-9378360412585533/9070213727';
+
+    RewardedAd.load(
+      adUnitId: adUnitId,
+      request: const AdRequest(),
+      rewardedAdLoadCallback: RewardedAdLoadCallback(
+        onAdLoaded: (RewardedAd ad) {
+          debugPrint('Rewarded ad loaded.');
+          setState(() {
+            _rewardedAd = ad;
+          });
+          // Set a full-screen content callback to handle events.
+          _rewardedAd!.fullScreenContentCallback = FullScreenContentCallback(
+            onAdDismissedFullScreenContent: (RewardedAd ad) {
+              ad.dispose();
+              _loadRewardedAd(); // Load a new ad after this one is dismissed.
+            },
+            onAdFailedToShowFullScreenContent: (RewardedAd ad, AdError error) {
+              debugPrint('Failed to show rewarded ad: $error');
+              ad.dispose();
+              _loadRewardedAd();
+            },
+          );
+        },
+        onAdFailedToLoad: (LoadAdError error) {
+          debugPrint('RewardedAd failed to load: $error');
+        },
+      ),
+    );
+  }
+
+  void _showRewardedAd() {
+    if (_rewardedAd == null) {
+      debugPrint('Warning: Rewarded ad is not ready yet.');
+      return;
+    }
+
+    _rewardedAd!.show(onUserEarnedReward: (AdWithoutView ad, RewardItem reward) {
+      debugPrint('User earned reward of ${reward.amount} ${reward.type}');
+      // Reward the user with an extra hint.
+      _grantExtraHint();
+      _onHintTap();
+    });
+  }
+
+  void _grantExtraHint() {
+    _sudokuBoard.grantExtraHint();
   }
 
   void _startTimer() {
@@ -155,7 +242,8 @@ class _GameScreenState extends State<GameScreen> {
       final String message;
       switch (e.reason) {
         case NoHintReason.noMoreHints:
-          message = l10n.noMoreHintsMessage;
+          _showRewardedAd();
+          return;
           break;
         case NoHintReason.boardIsCorrect:
           message = l10n.boardIsCorrectMessage;
@@ -407,68 +495,78 @@ class _GameScreenState extends State<GameScreen> {
     return Theme(
       data: _lightTheme,
       child: Scaffold(
-        body: Builder(builder: (context) {
-          return Center(
-            child: SingleChildScrollView(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(vertical: 12.0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    SizedBox(
-                      width: componentWidth,
-                      child: GameHeader(
-                        elapsedTime: _elapsedTime,
-                        isBoardModified: _sudokuBoard.isModified(),
-                        onResetTap: () => _onResetTap(context),
-                        onNewGameTap: () => _onNewGameTap(context),
-                        onTimerTap: _togglePause,
-                        onStatsTap: _showStatsDialog,
-                        onHintTap: _onHintTap,
-                        isPaused: _isPaused,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    SizedBox(
-                      width: componentWidth,
-                      height: componentWidth,
-                      child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: SudokuGrid(
-                          board: _sudokuBoard,
-                          selectedRow: _selectedRow,
-                          selectedCol: _selectedCol,
-                          onCellTap: _onCellTap,
-                          isPaused: _isPaused,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    AnimatedOpacity(
-                      opacity: _isPaused ? 0.0 : 1.0,
-                      duration: const Duration(milliseconds: 300),
-                      child: IgnorePointer(
-                        ignoring: _isPaused,
-                        child: Column(
-                          children: [
-                            SizedBox(
-                              width: componentWidth,
-                              child: NumberPad(
-                                onNumberTap: _onNumberTap,
-                                onEraseTap: _onEraseTap,
-                                getOccurrences: _sudokuBoard.countOccurrences,
+        body: Column(
+          children: [
+            Expanded(
+              child: Builder(builder: (context) {
+                return Center(
+                  child: SingleChildScrollView(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 12.0),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          SizedBox(
+                            width: componentWidth,
+                            child: GameHeader(
+                              elapsedTime: _elapsedTime,
+                              isBoardModified: _sudokuBoard.isModified(),
+                              onResetTap: () => _onResetTap(context),
+                              onNewGameTap: () => _onNewGameTap(context),
+                              onTimerTap: _togglePause,
+                              onStatsTap: _showStatsDialog,
+                              onHintTap: _onHintTap,
+                              isPaused: _isPaused,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          SizedBox(
+                            width: componentWidth,
+                            height: componentWidth,
+                            child: Padding(
+                              padding: const EdgeInsets.all(8.0),
+                              child: SudokuGrid(
+                                board: _sudokuBoard,
+                                selectedRow: _selectedRow,
+                                selectedCol: _selectedCol,
+                                onCellTap: _onCellTap,
+                                isPaused: _isPaused,
                               ),
                             ),
-                          ],
-                        ),
+                          ),
+                          const SizedBox(height: 8),
+                          AnimatedOpacity(
+                            opacity: _isPaused ? 0.0 : 1.0,
+                            duration: const Duration(milliseconds: 300),
+                            child: IgnorePointer(
+                              ignoring: _isPaused,
+                              child: SizedBox(
+                                width: componentWidth,
+                                child: NumberPad(
+                                  onNumberTap: _onNumberTap,
+                                  onEraseTap: _onEraseTap,
+                                  getOccurrences: _sudokuBoard.countOccurrences,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
+                  ),
+                );
+              }),
+            ),
+            if (_bannerAd != null)
+              SafeArea(
+                child: SizedBox(
+                  width: _bannerAd!.size.width.toDouble(),
+                  height: _bannerAd!.size.height.toDouble(),
+                  child: AdWidget(ad: _bannerAd!),
                 ),
               ),
-            ),
-          );
-        }),
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -166,6 +166,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      sha256: "4775006383a27a5d86d46f8fb452bfcb17794fc0a46c732979e49a8eb1c8963f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.0"
   image:
     dependency: transitive
     description:
@@ -467,6 +475,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webview_flutter:
+    dependency: transitive
+    description:
+      name: webview_flutter
+      sha256: "6869c8786d179f929144b4a1f86e09ac0eddfe475984951ea6c634774c16b522"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: ed021f27ae621bc97a6019fb601ab16331a3db4bf8afa305e9f6689bdb3edced
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.16.8"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "7cb32b21825bd65569665c32bb00a34ded5779786d6201f5350979d2d529940d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.13.0"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: "9c62cc46fa4f2d41e10ab81014c1de470a6c6f26051a2de32111b2ee55287feb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.14.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: sudokode
 description: An AI-powered Sudoku game built with Flutter and Dart. Challenge yourself with generated puzzles and get a little help when you're stuck.
 publish_to: 'none'
 
-version: 1.0.1+30
+version: 1.0.2+31
 
 environment:
   sdk: '>=3.4.0 <4.0.0'
@@ -19,6 +19,7 @@ dependencies:
       url: https://github.com/SoloScripted/flutter-shared-components.git
   intl: ^0.19.0
   shared_preferences: ^2.3.3
+  google_mobile_ads: ^5.2.0
 
 dev_dependencies:
   flutter_lints: ^2.0.3


### PR DESCRIPTION
This commit introduces rewarded video ads, allowing users to earn an extra hint when they have run out of their initial hints. A banner ad has also been added to the game screen.

Key changes:

Integrated the google_mobile_ads package for both banner and rewarded ads. Implemented logic in GameScreen to load, display, and handle ad lifecycle events. When a user without hints requests one, they are now prompted to watch a rewarded ad. Upon successful ad completion, the user is granted an extra hint. Added a new method grantExtraHint to SudokuBoard to support this functionality. Updated AndroidManifest.xml with the required AdMob App ID and permissions.